### PR TITLE
Fix: Blazer was not working correctly due to boss blind debuff

### DIFF
--- a/blinds/c_bossBlinds01.lua
+++ b/blinds/c_bossBlinds01.lua
@@ -19,19 +19,19 @@ local debuff_type = function(ptype)
             y:set_debuff(false)
         end
 
-        local blazer_index
+        local elementals_index
         for i, v in pairs(G.jokers.cards) do
-            if v.config.center_key == 'j_ina_Blazer' and 'j_ina_Weathervane' and 'j_ina_Noggin' and 'j_ina_Montayne' then
-                blazer_index = i
+            if v.config.center_key == C.ELEMENTALS_KEYS then
+                elementals_index = i
             elseif v.ability.extra.ptype == ptype then
                 v:set_debuff(true)
                 v:juice_up()
                 G.GAME.blind:wiggle()
             end
         end
-        if blazer_index then
-            G.jokers.cards[blazer_index]:set_debuff(true)
-            G.jokers.cards[blazer_index]:juice_up()
+        if elementals_index then
+            G.jokers.cards[elementals_index]:set_debuff(true)
+            G.jokers.cards[elementals_index]:juice_up()
             G.GAME.blind:wiggle()
         end
     end

--- a/helpers/consts.lua
+++ b/helpers/consts.lua
@@ -53,6 +53,7 @@ for _ in pairs(C.CUSTOM.Bobby_Teams) do
 end
 C.CUSTOM.Bobby_Teams_Number = team_number
 
+C.ELEMENTALS_KEYS = { j_ina_Weathervane = true, j_ina_Noggin = true, j_ina_Montayne = true, j_ina_Blazer = true }
 
 --- FOR GENERAL CREDITS
 C.CREDITS = {}

--- a/helpers/player_helper.lua
+++ b/helpers/player_helper.lua
@@ -217,13 +217,9 @@ get_random_joker_key = function(pseed, inararity, area, inateam, exclude_keys, e
         if ((special and v.special == special) or v.pteam)
             and not (inararity and v.rarity ~= inararity)
             and not (inateam and v.pteam and inateam ~= v.pteam)
-            and (
-                (special and v.special == special) -- cuando hay special, valida solo esto
-                or (not special and (player_in_pool(v) or (inateam == 'Scout' and v.pteam == 'Scout')))
-            )
+            and ((special and v.special == special) or (not special and player_in_pool(v)) or (v.pteam == 'Scout'))
             and not v.aux_ina
-            and not exclude_keys[v.key]
-        then
+            and not exclude_keys[v.key] then
             local no_dup = true
             if not enable_dupes and inaarea and inaarea.cards and not next(find_joker("Showman")) then
                 for _, m in pairs(inaarea.cards) do

--- a/helpers/player_helper.lua
+++ b/helpers/player_helper.lua
@@ -217,9 +217,13 @@ get_random_joker_key = function(pseed, inararity, area, inateam, exclude_keys, e
         if ((special and v.special == special) or v.pteam)
             and not (inararity and v.rarity ~= inararity)
             and not (inateam and v.pteam and inateam ~= v.pteam)
-            and ((special and v.special == special) or (not special and player_in_pool(v)) or (v.pteam == 'Scout'))
+            and (
+                (special and v.special == special) -- cuando hay special, valida solo esto
+                or (not special and (player_in_pool(v) or (inateam == 'Scout' and v.pteam == 'Scout')))
+            )
             and not v.aux_ina
-            and not exclude_keys[v.key] then
+            and not exclude_keys[v.key]
+        then
             local no_dup = true
             if not enable_dupes and inaarea and inaarea.cards and not next(find_joker("Showman")) then
                 for _, m in pairs(inaarea.cards) do

--- a/players/l_scouts.lua
+++ b/players/l_scouts.lua
@@ -99,17 +99,14 @@ local Blazer = J({
     pools = { ["Scout"] = true },
     cost = 5,
     atlas = "Jokers10",
-    ptype = C.Fire,
-    pposition = C.GK,
+    ptype = "Fire",
+    pposition = "GK",
     pteam = "Scout",
     blueprint_compat = true,
     allow_element_application = true,
     calculate = function(self, card, context)
         for _, player in pairs(G.jokers.cards) do
-            if player.config.center_key == 'j_ina_Weathervane' or
-                player.config.center_key == 'j_ina_Blazer' or
-                player.config.center_key == 'j_ina_Montayne' or
-                player.config.center_key == 'j_ina_Noggin' then
+            if C.ELEMENTALS_KEYS[player.config.center_key] then
                 leftmost = player
                 break
             end
@@ -120,7 +117,9 @@ local Blazer = J({
         end
     end,
     remove_from_deck = function(self, card, from_debuff)
-        restore_types_for_area()
+        if leftmost == card then
+            restore_types_for_area()
+        end
     end
 })
 
@@ -143,10 +142,7 @@ local Weathervane = J({
     allow_element_application = true,
     calculate = function(self, card, context)
         for _, player in pairs(G.jokers.cards) do
-            if player.config.center_key == 'j_ina_Blazer' or
-                player.config.center_key == 'j_ina_Montayne' or
-                player.config.center_key == 'j_ina_Weathervane' or
-                player.config.center_key == 'j_ina_Noggin' then
+            if C.ELEMENTALS_KEYS[player.config.center_key] then
                 leftmost = player
                 break
             end
@@ -157,7 +153,9 @@ local Weathervane = J({
         end
     end,
     remove_from_deck = function(self, card, from_debuff)
-        restore_types_for_area()
+        if leftmost == card then
+            restore_types_for_area()
+        end
     end
 })
 
@@ -180,10 +178,7 @@ local Noggin = J({
     allow_element_application = true,
     calculate = function(self, card, context)
         for _, player in pairs(G.jokers.cards) do
-            if player.config.center_key == 'j_ina_Weathervane' or
-                player.config.center_key == 'j_ina_Noggin' or
-                player.config.center_key == 'j_ina_Montayne' or
-                player.config.center_key == 'j_ina_Blazer' then
+            if C.ELEMENTALS_KEYS[player.config.center_key] then
                 leftmost = player
                 break
             end
@@ -194,7 +189,9 @@ local Noggin = J({
         end
     end,
     remove_from_deck = function(self, card, from_debuff)
-        restore_types_for_area()
+        if leftmost == card then
+            restore_types_for_area()
+        end
     end
 })
 
@@ -217,10 +214,7 @@ local Montayne = J({
     allow_element_application = true,
     calculate = function(self, card, context)
         for _, player in pairs(G.jokers.cards) do
-            if player.config.center_key == 'j_ina_Weathervane' or
-                player.config.center_key == 'j_ina_Montayne' or
-                player.config.center_key == 'j_ina_Noggin' or
-                player.config.center_key == 'j_ina_Blazer' then
+            if C.ELEMENTALS_KEYS[player.config.center_key] then
                 leftmost = player
                 break
             end
@@ -231,7 +225,9 @@ local Montayne = J({
         end
     end,
     remove_from_deck = function(self, card, from_debuff)
-        restore_types_for_area()
+        if leftmost == card then
+            restore_types_for_area()
+        end
     end
 })
 


### PR DESCRIPTION
- Fixed that Blazer did not behave like other elementals when applying its element during a boss blind.
- Updated variable names in `debuff_type`.
- Now using the constant `C.ELEMENTALS_KEYS` to check for elemental Jokers.